### PR TITLE
Create Docker images for base, UI, server and devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,57 +1,54 @@
-FROM gcart/jupyter:latest
+ARG UI_IMAGE=cadaver-exquisito/ui:latest
+FROM ${UI_IMAGE} AS ui_image
 
-WORKDIR /tmp
+ARG SERVER_IMAGE=cadaver-exquisito/server:latest
+FROM ${SERVER_IMAGE} AS server_image
+
+FROM server_image
 
 ARG USER_NAME=vscode
-ARG USER_UID
-ARG USER_GID
-ARG DOCKER_GID
+ARG USER_UID=1000
+ARG USER_GID=1000
 
-RUN groupadd --gid $USER_GID $USER_NAME \
-    && useradd --uid $USER_UID --gid $USER_GID -m $USER_NAME \
-    && apt-get update \
-    && apt-get install -y sudo \
-    && echo $USER_NAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USER_NAME \
-    && chmod 0440 /etc/sudoers.d/$USER_NAME \
-    && apt-get autoremove -y \
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        git \
+        htop \
+        iproute2 \
+        less \
+        locales \
+        make \
+        openssh-client \
+        sudo \
+        vim \
+    && locale-gen en_US.UTF-8 \
     && apt-get clean \
-    && rm -rf /tmp/* /var/tmp/* \
     && rm -rf /var/lib/apt/lists/*
 
-ENV SHELL=/usr/bin/zsh
-RUN chsh $USER_NAME -s $SHELL
+RUN groupadd --gid ${USER_GID} ${USER_NAME} \
+    && useradd --uid ${USER_UID} --gid ${USER_GID} -m ${USER_NAME} \
+    && echo "${USER_NAME} ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/${USER_NAME} \
+    && chmod 0440 /etc/sudoers.d/${USER_NAME}
 
-# RUN mkdir /root/tests
-RUN ln -s /workspace/test /root/tests
+ENV LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8 \
+    PATH="/opt/venv/bin:${PATH}"
 
-# Install dev dependences & tools
-RUN apt update && apt install -y \
-    htop \
-    vim \
-    git-lfs \
-    apt-transport-https \
-    ca-certificates \
-    curl \
-    gnupg \
-    lsb-release \
-    ssh \
-    rsync \
-    kmod \
-    sudo \
-    make \
-    && apt-get autoremove -y \
-    && apt-get clean \
-    && rm -rf /tmp/* /var/tmp/* \
-    && rm -rf /var/lib/apt/lists/*
+COPY .devcontainer/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
-# Install dev packages
-COPY .devcontainer/requirements.txt .
-RUN --mount=type=cache,target=/root/.cache \
-    pip install -r requirements.txt
+# Ensure UI tooling is also available when developing the server
+RUN pip install --no-cache-dir streamlit
 
+COPY --from=ui_image /workspace/ui /opt/templates/ui
 
-RUN chown -R ${USER_NAME} /root
+WORKDIR /workspace
 
-USER vscode
-RUN sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
-ENV PATH=$PATH:/home/vscode/.local/bin
+RUN chown -R ${USER_NAME}:${USER_GID} /workspace
+
+USER ${USER_NAME}
+
+CMD ["/bin/bash"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,10 +5,10 @@
 	"runServices": [
 		"cadaver-exquisito-dev"
 	],
-	"workspaceFolder": "/workspace",
-	"customizations": {
-		"vscode": {
-			"extensions": [
+        "workspaceFolder": "/workspace",
+        "customizations": {
+                "vscode": {
+                        "extensions": [
 				"eamodio.gitlens",
 				"markis.code-coverage",
 				"ms-azuretools.vscode-docker",
@@ -22,21 +22,21 @@
 				"sonarsource.sonarlint-vscode",
 				"waderyan.gitblame"
 			],
-			"settings": {
-				"python.pythonPath": "/bin/python",
-				"python.languageServer": "Pylance",
-				"python.linting.enabled": true,
-				"python.linting.flake8Enabled": true,
-				"python.linting.pylintEnabled": true,
-				"python.linting.pycodestyleEnabled": false,
-				"python.formatting.blackPath": "/usr/local/bin/black",
-				"python.linting.flake8Path": "/usr/local/bin/flake8",
-				"editor.formatOnSave": true,
-				"files.trimFinalNewlines": true,
-				"files.trimTrailingWhitespace": true,
-				"files.watcherExclude": {
-					".git/**": true,
-				}
+                        "settings": {
+                                "python.defaultInterpreterPath": "/opt/venv/bin/python",
+                                "python.languageServer": "Pylance",
+                                "python.linting.enabled": true,
+                                "python.linting.flake8Enabled": true,
+                                "python.linting.pylintEnabled": true,
+                                "python.linting.pycodestyleEnabled": false,
+                                "python.formatting.blackPath": "/opt/venv/bin/black",
+                                "python.linting.flake8Path": "/opt/venv/bin/flake8",
+                                "editor.formatOnSave": true,
+                                "files.trimFinalNewlines": true,
+                                "files.trimTrailingWhitespace": true,
+                                "files.watcherExclude": {
+                                        ".git/**": true
+                                }
 			}
 		}
 	},

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,17 +1,20 @@
 version: "3.8"
 services:
-    cadaver-exquisito-dev:
-        network_mode: host
-        image: cadaver-exquisito-dev
-        container_name: cadaver-exquisito-dev
-        build:
-            context: ..
-            dockerfile: .devcontainer/Dockerfile
-            args:
-                - USER_NAME=vscode
-                - USER_UID=1000
-                - USER_GID=1000
-        volumes:
-            - $HOME/.ssh/:/home/vscode/.ssh
-            - $HOME/.gitconfig:/home/vscode/.gitconfig
-        command: /bin/sh -c "while sleep 1000; do :; done"
+  cadaver-exquisito-dev:
+    network_mode: host
+    image: cadaver-exquisito-dev
+    container_name: cadaver-exquisito-dev
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+      args:
+        USER_NAME: vscode
+        USER_UID: 1000
+        USER_GID: 1000
+        UI_IMAGE: cadaver-exquisito/ui:latest
+        SERVER_IMAGE: cadaver-exquisito/server:latest
+    volumes:
+      - ..:/workspace:cached
+      - $HOME/.ssh/:/home/vscode/.ssh:ro
+      - $HOME/.gitconfig:/home/vscode/.gitconfig:ro
+    command: /bin/sh -c "while sleep 1000; do :; done"

--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -1,11 +1,30 @@
 FROM ubuntu:24.04
 
-# use env and delete this
-ENV PIP_BREAK_SYSTEM_PACKAGES 1
+ARG DEBIAN_FRONTEND=noninteractive
 
-WORKDIR /root
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8
 
 RUN apt-get update \
-    && apt-get install -y python3 python3-venv python3-pip
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        curl \
+        git \
+        locales \
+        python3 \
+        python3-dev \
+        python3-pip \
+        python3-venv \
+    && locale-gen en_US.UTF-8 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --upgrade pip setuptools
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv ${VIRTUAL_ENV} \
+    && ${VIRTUAL_ENV}/bin/pip install --upgrade pip setuptools wheel
+
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+
+WORKDIR /workspace

--- a/containers/server/Dockerfile
+++ b/containers/server/Dockerfile
@@ -1,0 +1,13 @@
+ARG BASE_IMAGE=cadaver-exquisito/base:latest
+FROM ${BASE_IMAGE}
+
+ENV APP_HOME=/workspace/server \
+    APP_PORT=8000
+
+WORKDIR ${APP_HOME}
+
+RUN pip install --no-cache-dir fastapi "uvicorn[standard]"
+
+EXPOSE 8000
+
+CMD ["python", "-m", "http.server", "8000"]

--- a/containers/ui/Dockerfile
+++ b/containers/ui/Dockerfile
@@ -1,10 +1,14 @@
-ARG IMAGE
-FROM ${IMAGE}
+ARG BASE_IMAGE=cadaver-exquisito/base:latest
+FROM ${BASE_IMAGE}
 
-COPY ./src/ui /tmp/ui
+ENV STREAMLIT_SERVER_PORT=8501
 
-#RUN pip install --no-cache-dir /tmp/ui
+WORKDIR /workspace/ui
 
-#EXPOSE 8501
+COPY src/ui/ ./src
 
-#CMD ["streamlit", "run", "/tmp/web/web/Home.py"]
+RUN pip install --no-cache-dir streamlit
+
+EXPOSE 8501
+
+CMD ["streamlit", "hello"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,36 @@
 services:
   base:
-    image: base:latest
-    container_name: base
-    build: 
+    image: cadaver-exquisito/base:latest
+    build:
       context: .
       dockerfile: ./containers/base/Dockerfile
+
+  server:
+    image: cadaver-exquisito/server:latest
+    build:
+      context: .
+      dockerfile: ./containers/server/Dockerfile
+      args:
+        BASE_IMAGE: cadaver-exquisito/base:latest
+    environment:
+      APP_PORT: ${APP_PORT:-8000}
+    ports:
+      - "${APP_PORT:-8000}:8000"
+    depends_on:
+      - base
+
   ui:
-    image: ui:latest
-    container_name: ui
-    build: 
+    image: cadaver-exquisito/ui:latest
+    build:
       context: .
       dockerfile: ./containers/ui/Dockerfile
       args:
-        - IMAGE=base:latest
-#    environment:
-#      - BACKEND_HOST=app
-#      - BACKEND_PORT=${BACKEND_PORT}
-#    ports:
-#      - "8008:8501"
+        BASE_IMAGE: cadaver-exquisito/base:latest
+    environment:
+      STREAMLIT_SERVER_PORT: ${STREAMLIT_SERVER_PORT:-8501}
+      BACKEND_HOST: ${BACKEND_HOST:-server}
+      BACKEND_PORT: ${BACKEND_PORT:-8000}
+    ports:
+      - "${STREAMLIT_SERVER_PORT:-8501}:8501"
+    depends_on:
+      - server


### PR DESCRIPTION
## Summary
- rebuild the base image on Ubuntu 24.04 with a dedicated Python virtual environment
- add UI and server images derived from the base image and wire them up in docker-compose with sensible defaults
- create a devcontainer image that layers on the server image, pulls in UI tooling, and exposes the workspace for VS Code

## Testing
- docker compose config *(fails: docker is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d57dc21d58832d8ee5f67ca5f18ab8